### PR TITLE
Fix remote endpoint exception

### DIFF
--- a/bcos-boostssl/httpserver/HttpServer.cpp
+++ b/bcos-boostssl/httpserver/HttpServer.cpp
@@ -113,11 +113,17 @@ void HttpServer::onAccept(boost::beast::error_code ec, boost::asio::ip::tcp::soc
     }
 
     auto localEndpoint = socket.local_endpoint();
-    auto remoteEndpoint = socket.remote_endpoint();
+    boost::system::error_code sec;
+    auto remoteEndpoint = socket.remote_endpoint(sec);
+    if(sec) {
+        HTTP_SERVER(WARNING) << LOG_BADGE("accept") << LOG_KV("remote_endpoint error", sec)
+                             << LOG_KV("message", sec.message());
+        return doAccept();
+    }
     socket.set_option(boost::asio::ip::tcp::no_delay(true));
 
-    HTTP_SERVER(INFO) << LOG_BADGE("accept") << LOG_KV("local_endpoint", socket.local_endpoint())
-                      << LOG_KV("remote_endpoint", socket.remote_endpoint());
+    HTTP_SERVER(INFO) << LOG_BADGE("accept") << LOG_KV("local_endpoint", localEndpoint)
+                      << LOG_KV("remote_endpoint", remoteEndpoint);
 
     bool useSsl = !disableSsl();
     if (!useSsl)

--- a/bcos-boostssl/httpserver/HttpServer.cpp
+++ b/bcos-boostssl/httpserver/HttpServer.cpp
@@ -112,12 +112,19 @@ void HttpServer::onAccept(boost::beast::error_code ec, boost::asio::ip::tcp::soc
         return doAccept();
     }
 
-    auto localEndpoint = socket.local_endpoint();
     boost::system::error_code sec;
+    auto localEndpoint = socket.local_endpoint(sec);
+    if(sec) {
+        HTTP_SERVER(WARNING) << LOG_BADGE("accept") << LOG_KV("local_endpoint error", sec)
+                             << LOG_KV("message", sec.message());
+        ws::WsTools::close(socket);
+        return doAccept();
+    }
     auto remoteEndpoint = socket.remote_endpoint(sec);
     if(sec) {
         HTTP_SERVER(WARNING) << LOG_BADGE("accept") << LOG_KV("remote_endpoint error", sec)
                              << LOG_KV("message", sec.message());
+        ws::WsTools::close(socket);
         return doAccept();
     }
     socket.set_option(boost::asio::ip::tcp::no_delay(true));

--- a/test/exec/http_server_sample.cpp
+++ b/test/exec/http_server_sample.cpp
@@ -88,9 +88,9 @@ int main(int argc, char** argv)
 
     auto server = wsService->httpServer();
     server->setHttpReqHandler(
-        [](const std::string& _req, std::function<void(const std::string& resp)> _callback) {
+        [](const std::string_view _req, std::function<void(bcos::bytes)> _callback) {
             BCOS_LOG(INFO) << LOG_BADGE(" [Main] ===>>>> ") << LOG_KV("request", _req);
-            _callback(_req);
+            _callback(bcos::bytes(_req.begin(), _req.end()));
         });
     wsService->start();
 


### PR DESCRIPTION
# 问题
fisco-bcos 在运行过程中，rpc 服务在抛出异常后拒绝接受新连接。相关日志如下：
```
435 warning|2022-10-20 11:05:32.684461|[WS][SERVICE][startIocThread]Exception in IOC Thread:Throw location unknown (consider using BOOST_THROW_EXCEPTION)
436 Dynamic exception type: boost::wrapexcept<boost::system::system_error>
437 std::exception::what: remote_endpoint: Transport endpoint is not connected
```

# 复现 
按照 https://fisco-bcos-doc.readthedocs.io/zh_CN/release-3.0.0-rc3/docs/quick_start/air_installation.html 启动 fisco-bcos，然后执行以下命令，会导致节点 rpc 服务抛出异常
```bash 
# 正常连接 
telnet 127.0.0.1 20200 

# 触发异常（大概率会触发，如没有触发多重试几次）
 nmap -p 20200 127.0.0.1 # syn 扫描，其实就是 tcp 第三次握手发送 reset

# 查看日志发现 rpc 已经抛出异常，并拒绝新连接
telnet 127.0.0.1 20200 
```

另外也可以直接使用 `test/exec/http_server_sample.cpp` 进行复现。
